### PR TITLE
add privacy class

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can choose the following method that suits you to install the plugin
 ### Using Terminal
 Go to your moodle root directory and execute the following command
 ```
-git clone https://github.com/thoriqadillah/essaysimilarity.git question/type/essaysimilarity
+git clone https://github.com/thoriqadillah/moodle-qtype_essaysimilarity.git question/type/essaysimilarity
 ```
 ### Manual
 Download the zip and extract it to the question/type inside your moodle root directory

--- a/classes/privacy/provide.php
+++ b/classes/privacy/provide.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for qtype_essaysimilarity.
+ *
+ * @package    qtype_essaysimilarity
+ * @copyright  2023 Atthoriq Adillah Wicaksana (thoriqadillah59@gmail.com)
+ * @copyright  based on work by 2018 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace qtype_essaysimilarity\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy Subsystem for qtype_essaysimilarity implementing null_provider.
+ *
+ * @copyright  2023 Atthoriq Adillah Wicaksana (thoriqadillah59@gmail.com)
+ * @copyright  based on work by 2018 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}


### PR DESCRIPTION
This PR solve isssue [#10](https://github.com/thoriqadillah/moodle-qtype_essaysimilarity/issues/10) that requires this plugin to implements Moodle Privacy API.

Because this plugin inspired by [Essay Auto Grade](https://github.com/gbateson/moodle-qtype_essayautograde/blob/master/classes/privacy/provider.php), and said plugin states it doesn't store user data, so does this plugin. Instead, this plugin stores student's answer and then use it accordingly to auto grade and display it on grading page