### PR TITLE
change table name to comply with moodle convention

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -36,7 +36,7 @@
         <KEY NAME="questionid" TYPE="foreign-unique" FIELDS="questionid" REFTABLE="question" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
-    <TABLE NAME="question_answer_stats" COMMENT="Text statistics from essaysimilarity">
+    <TABLE NAME="qtype_essaysimilarity_stats" COMMENT="Text statistics from essaysimilarity">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="questionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Foreign key linking to the question table."/>

--- a/question.php
+++ b/question.php
@@ -79,7 +79,7 @@ class qtype_essaysimilarity_question extends qtype_essay_question implements que
     global $USER, $DB;
 
     // get all text stats and then save to DB according what user choose in form editing
-    $textstats_table = 'question_answer_stats';
+    $textstats_table = 'qtype_essaysimilarity_stats';
     $oldtextstats = $DB->get_record($textstats_table, ['questionid' => $this->id, 'userid' => $USER->id]);
 
     $stats = $this->get_stats($responsetext);

--- a/renderer.php
+++ b/renderer.php
@@ -65,6 +65,10 @@ class qtype_essaysimilarity_renderer extends qtype_renderer {
     }
 
     $renderer = $question->get_format_renderer($this->page);
+    if (method_exists($renderer, 'set_displayoptions')) {
+      $renderer->set_displayoptions($options); // Moodle 4.x and later
+    }
+    
     $linecount = $question->responsefieldlines;
 
     $answer = $renderer->response_area_input('answer', $qa, $step, $linecount, $options->context);


### PR DESCRIPTION
This PR solve issue [#5](https://github.com/thoriqadillah/moodle-qtype_essaysimilarity/issues/5)

Changing DB table name from `question_answer_stats` to `qtype_essaysimilarity_stats` to comply with moodle naming convention
