### PR TITLE
change param_text to param_alpha

### DIFF
--- a/edit_essaysimilarity_form.php
+++ b/edit_essaysimilarity_form.php
@@ -24,8 +24,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use function PHPUnit\Framework\returnSelf;
-
 defined('MOODLE_INTERNAL') || die();
 
 //get parent class
@@ -72,7 +70,7 @@ class qtype_essaysimilarity_edit_form extends qtype_essay_edit_form {
     $label = get_string($name, $plugin);
     $mform->addElement('select', $name, $label, $this->language_options());
     $mform->addHelpButton($name, $name, $plugin);
-    $mform->setType($name, PARAM_TEXT);
+    $mform->setType($name, PARAM_ALPHA);
     $mform->setDefault($name, $this->get_default($name, $this->get_constant('NO_LANG')));
     
     

--- a/nlp/tokenizer.php
+++ b/nlp/tokenizer.php
@@ -8,7 +8,7 @@ class tokenizer {
   private $lang = 'none';
 
   public function __construct($lang) {
-    $this->lang = $lang;
+    $this->lang = clean_param($lang, PARAM_ALPHA);
   }
 
   /**
@@ -21,7 +21,7 @@ class tokenizer {
     $str = $this->normalize($str);
     $token = preg_split('/[\pZ\pC]+/u', $str, -1, PREG_SPLIT_NO_EMPTY);
     
-    // we assume that stemmer implementation and stopword dictionary for certain language is present, or errors will be thrown
+    // we assume that stemmer implementation and stopword dictionary for certain language is present, otherwise errors will be thrown
     if ($this->lang !== 'none') {
       require_once("stemmer/$this->lang/$this->lang.php");
 

--- a/renderer.php
+++ b/renderer.php
@@ -27,6 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/lib/questionlib.php');
+require_once($CFG->dirroot.'/question/type/essay/renderer.php');
 /**
  * The essaysimilarity question type renderer.
  *
@@ -400,7 +401,6 @@ class qtype_essaysimilarity_renderer extends qtype_renderer {
 
 }
 
-require_once($CFG->dirroot.'/question/type/essay/renderer.php');
 /**
  * An essaysimilarity format renderer for essaysimilaritys where the student should not enter
  * any inline response.


### PR DESCRIPTION
This PR solve [#9](https://github.com/thoriqadillah/moodle-qtype_essaysimilarity/issues/9)

Changing `PARAM_TEXT` to `PARAM_ALPHA` and add `clean_param()` on class constructor to clean the parameter before using it on tokenizer function. With this, hopefully will prevent potential option for directory traversal attack. Thanks to @danmarsden.

This PR also update the code to solve [#7](https://github.com/thoriqadillah/moodle-qtype_essaysimilarity/issues/7)